### PR TITLE
removed using count and use flatten & for_each instead

### DIFF
--- a/terraform/terraform.tfstate
+++ b/terraform/terraform.tfstate
@@ -1,7 +1,7 @@
 {
   "version": 4,
   "terraform_version": "1.10.2",
-  "serial": 71,
+  "serial": 206,
   "lineage": "0add552f-3b0b-1046-bf0e-4029a97d68f8",
   "outputs": {},
   "resources": [
@@ -12,12 +12,12 @@
       "provider": "provider[\"registry.terraform.io/integrations/github\"]",
       "instances": [
         {
-          "index_key": 0,
+          "index_key": "github-config-120m",
           "schema_version": 0,
           "attributes": {
             "color": "f39800",
             "description": "",
-            "etag": "W/\"0b580fddc02bd22747e41b0a6d8ad626f84469d83a2bcf8e0e8c2afc5155cab5\"",
+            "etag": "W/\"02e30c3195f8152e7ab439e2c92ab7c0d942061940342155ea45a7caf72d44e4\"",
             "id": "github-config:120m",
             "name": "120m",
             "repository": "github-config",
@@ -27,12 +27,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 1,
+          "index_key": "github-config-15m",
           "schema_version": 0,
           "attributes": {
             "color": "fffcdb",
             "description": "",
-            "etag": "W/\"f1cdc1dbaaeb954ca341d5f9d93ae35465f33b914b75ec7f153c0b2033686e72\"",
+            "etag": "W/\"91f82885c584558eb6c98e4231c55b560703e923f54f27768dc800a2483a4bc5\"",
             "id": "github-config:15m",
             "name": "15m",
             "repository": "github-config",
@@ -42,12 +42,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 2,
+          "index_key": "github-config-30m",
           "schema_version": 0,
           "attributes": {
             "color": "d4ecea",
             "description": "",
-            "etag": "W/\"664606d0126a898c5f9c19dab3b8fcf27c2a6305f76f599abf5a29c97e3e6ba8\"",
+            "etag": "W/\"66a5b06d1e12905111868968f5e237895d565ae5bff5d697b89d62aa08155156\"",
             "id": "github-config:30m",
             "name": "30m",
             "repository": "github-config",
@@ -57,12 +57,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 3,
+          "index_key": "github-config-45m",
           "schema_version": 0,
           "attributes": {
             "color": "ae7a26",
             "description": "",
-            "etag": "W/\"8dabf3b9e8211062123bd3f54132efa716feb19c08339484ca86f0bc7ceea40c\"",
+            "etag": "W/\"5ce0afeeb4a45a2ec29b0a3777043b873d5cabe5c6039bc3cdfd04d41e510199\"",
             "id": "github-config:45m",
             "name": "45m",
             "repository": "github-config",
@@ -72,12 +72,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 4,
+          "index_key": "github-config-60m",
           "schema_version": 0,
           "attributes": {
             "color": "0068b7",
             "description": "",
-            "etag": "W/\"8139076d1e2a4e44e007d7d2476d080f03dd565fc1724c79ce0b15fe745d0fc7\"",
+            "etag": "W/\"927f696b6a3fb4f6afda9d377e139953b3ee92770189c5a8b8a3702ccd1d68f5\"",
             "id": "github-config:60m",
             "name": "60m",
             "repository": "github-config",
@@ -87,12 +87,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 5,
+          "index_key": "github-config-90m",
           "schema_version": 0,
           "attributes": {
             "color": "914487",
             "description": "",
-            "etag": "W/\"22bd18e38110e4de5ef9c9aff75da873391380a3b1dd8ddd9ce10cc919f4b15a\"",
+            "etag": "W/\"2fe5a4c84fa7fbe7bc1148ce161908211e758fbed339ac017d9dedd3d1baadcd\"",
             "id": "github-config:90m",
             "name": "90m",
             "repository": "github-config",
@@ -102,12 +102,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 6,
+          "index_key": "tasks-120m",
           "schema_version": 0,
           "attributes": {
             "color": "f39800",
             "description": "",
-            "etag": "W/\"0586f018c0a4efd5ed067981d4e7b0e20a015b7e2ad601f02df7df1ea5509116\"",
+            "etag": "W/\"886808fd4746a294687210ac9814832977a1dfa6e51f9e017e3bdf03d2c086ad\"",
             "id": "tasks:120m",
             "name": "120m",
             "repository": "tasks",
@@ -117,12 +117,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 7,
+          "index_key": "tasks-15m",
           "schema_version": 0,
           "attributes": {
             "color": "fffcdb",
             "description": "",
-            "etag": "W/\"da3419c6485007962b62f1a57e6f6171b8ad4b87466814cd9d85e878b3f3b05d\"",
+            "etag": "W/\"873f1374d5036e008a0d353b80ef1eceb969a0b482a7d81579aebccc21aca6fb\"",
             "id": "tasks:15m",
             "name": "15m",
             "repository": "tasks",
@@ -132,12 +132,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 8,
+          "index_key": "tasks-30m",
           "schema_version": 0,
           "attributes": {
             "color": "d4ecea",
             "description": "",
-            "etag": "W/\"efa6ffc415f2852f5ae4c92ef9b956c933b457b1d460f19306b0c3ff1f60aaf1\"",
+            "etag": "W/\"795517b231d441e9c0fe8e7c6368f9a2c20b6a3a87d5a7e89b78f4996c5a1fc6\"",
             "id": "tasks:30m",
             "name": "30m",
             "repository": "tasks",
@@ -147,12 +147,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 9,
+          "index_key": "tasks-45m",
           "schema_version": 0,
           "attributes": {
             "color": "ae7a26",
             "description": "",
-            "etag": "W/\"27e8a14953888b3851455d2af2d9fa32fa1b66ae439c05424f5057240b8b443f\"",
+            "etag": "W/\"15d76c836d0713b69375d186d8cadd1f5ca24dec50eba271487eb3ba39041bab\"",
             "id": "tasks:45m",
             "name": "45m",
             "repository": "tasks",
@@ -162,12 +162,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 10,
+          "index_key": "tasks-60m",
           "schema_version": 0,
           "attributes": {
             "color": "0068b7",
             "description": "",
-            "etag": "W/\"6c9162b19da405e327f446fb305cb2d58b0321c500b33dc2a238f598fcf50896\"",
+            "etag": "W/\"bc79ad183e53a0222755b3de99769215531ff3efe2a214aa08b3eef12a869ff4\"",
             "id": "tasks:60m",
             "name": "60m",
             "repository": "tasks",
@@ -177,12 +177,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 11,
+          "index_key": "tasks-90m",
           "schema_version": 0,
           "attributes": {
             "color": "914487",
             "description": "",
-            "etag": "W/\"dd616d4aa26fac03c055062de4d492fb3ad9593a99478b6146ed555c434bc85e\"",
+            "etag": "W/\"291ee3b56b06c52bca17a3e957f058b29b768dafee96253bc750f718edce4b71\"",
             "id": "tasks:90m",
             "name": "90m",
             "repository": "tasks",
@@ -200,12 +200,12 @@
       "provider": "provider[\"registry.terraform.io/integrations/github\"]",
       "instances": [
         {
-          "index_key": 0,
+          "index_key": "github-config-2023/01",
           "schema_version": 0,
           "attributes": {
             "color": "c7402c",
             "description": "",
-            "etag": "W/\"e8a4b67563442b991f21d65e6e52ce15cb551b3d45a5945b9c7f8cf57cf04d69\"",
+            "etag": "W/\"fa2353778bf953d00d7d41929e836742af5519bc50a59edc9d736ad7d08e2860\"",
             "id": "github-config:2023/01",
             "name": "2023/01",
             "repository": "github-config",
@@ -215,12 +215,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 1,
+          "index_key": "github-config-2023/02",
           "schema_version": 0,
           "attributes": {
             "color": "5e7db9",
             "description": "",
-            "etag": "W/\"8d69f08d71c45d9ee56714067083858b19941f04cd36aedc9e3fa5274c04d3c7\"",
+            "etag": "W/\"f6d8622c2ca4e3b0dee0ee6688c7bfb6ee2d88617d38500f9efbff083076a5c6\"",
             "id": "github-config:2023/02",
             "name": "2023/02",
             "repository": "github-config",
@@ -230,12 +230,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 2,
+          "index_key": "github-config-2023/03",
           "schema_version": 0,
           "attributes": {
             "color": "e8abb9",
             "description": "",
-            "etag": "W/\"981cf9566a6abdc8fbf4d87dd0da3709ea2ed41682a1dafa8159152689bb0496\"",
+            "etag": "W/\"3bd1ffb75af50c8ed6c1ced5afebd706b14966198788615d392199d9915fcf09\"",
             "id": "github-config:2023/03",
             "name": "2023/03",
             "repository": "github-config",
@@ -245,12 +245,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 3,
+          "index_key": "github-config-2023/04",
           "schema_version": 0,
           "attributes": {
             "color": "9ac244",
             "description": "",
-            "etag": "W/\"cdf93ad1effc985443f730049ce29b994655f980b2dde79e3ff8ab6d5b3beb6d\"",
+            "etag": "W/\"8077c7fd9591856652bda02b1147d5d3da9b33dc8e5e1f0403b813fa54ad10a5\"",
             "id": "github-config:2023/04",
             "name": "2023/04",
             "repository": "github-config",
@@ -260,12 +260,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 4,
+          "index_key": "github-config-2023/05",
           "schema_version": 0,
           "attributes": {
             "color": "49a099",
             "description": "",
-            "etag": "W/\"169116ec89da5eddaa1ef85efb98af1e0688c057937ed70c6e91d0ed5e25527a\"",
+            "etag": "W/\"8389dd06e964f5443237ce38267261f175ba0ceedd51b501bfad36ad2863c1c7\"",
             "id": "github-config:2023/05",
             "name": "2023/05",
             "repository": "github-config",
@@ -275,12 +275,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 5,
+          "index_key": "github-config-2023/06",
           "schema_version": 0,
           "attributes": {
             "color": "8e4993",
             "description": "",
-            "etag": "W/\"4f9af667433a1b2605ec2cfdac75fbd84bd86da39876a29b7855c113bc1d1a50\"",
+            "etag": "W/\"32d7486b3c30a0fcc4a19735b4acb49fbe0c4d5b3b2b4358a571708a4430e03b\"",
             "id": "github-config:2023/06",
             "name": "2023/06",
             "repository": "github-config",
@@ -290,12 +290,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 6,
+          "index_key": "github-config-2023/07",
           "schema_version": 0,
           "attributes": {
             "color": "4895d0",
             "description": "",
-            "etag": "W/\"d562d1c9af44f78ec3c965f50f1bbbf89a1fedba3b65afb13a20790c91f04576\"",
+            "etag": "W/\"62889641fa2456133c8430464484759b981638feec97dc3f8f1a17203cb7855c\"",
             "id": "github-config:2023/07",
             "name": "2023/07",
             "repository": "github-config",
@@ -305,12 +305,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 7,
+          "index_key": "github-config-2023/08",
           "schema_version": 0,
           "attributes": {
             "color": "d68838",
             "description": "",
-            "etag": "W/\"2670ff573b05a0df43d43a38e5acf6c3a93d153776fd096459a4f5ab665a963f\"",
+            "etag": "W/\"4c7e712688523687a6a1762b5029a18b0dd436467156b810ec1d232c00cd783d\"",
             "id": "github-config:2023/08",
             "name": "2023/08",
             "repository": "github-config",
@@ -320,12 +320,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 8,
+          "index_key": "github-config-2023/09",
           "schema_version": 0,
           "attributes": {
             "color": "3c5929",
             "description": "",
-            "etag": "W/\"530034683441b54fba9a590b4514028bd51f59f14deba0c2df8e15c5db52f8af\"",
+            "etag": "W/\"c93a783d397f1a939cd5cc8abd2401d961ff4344be2fd4d5d589bac179cd3c7f\"",
             "id": "github-config:2023/09",
             "name": "2023/09",
             "repository": "github-config",
@@ -335,12 +335,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 9,
+          "index_key": "github-config-2023/10",
           "schema_version": 0,
           "attributes": {
             "color": "e0b73e",
             "description": "",
-            "etag": "W/\"cc3455fc78e73921e5949fff64a4e48642dc506658d4bda7e2e827b19d670e47\"",
+            "etag": "W/\"b5ad084e23695dd91dc3b8efd7ac1d51cf83e40255990bc96ed0b0dd4aa8835c\"",
             "id": "github-config:2023/10",
             "name": "2023/10",
             "repository": "github-config",
@@ -350,12 +350,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 10,
+          "index_key": "github-config-2023/11",
           "schema_version": 0,
           "attributes": {
             "color": "763724",
             "description": "",
-            "etag": "W/\"0c7198a7490d51648db744fd229bd874cd0bf7ae549430e2dc1ce753effaf1a0\"",
+            "etag": "W/\"53b16814ab34213c821409d491a86b44a7135452fa5888d5457a16d07ff8281e\"",
             "id": "github-config:2023/11",
             "name": "2023/11",
             "repository": "github-config",
@@ -365,12 +365,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 11,
+          "index_key": "github-config-2023/12",
           "schema_version": 0,
           "attributes": {
             "color": "192983",
             "description": "",
-            "etag": "W/\"f968a46c0af25787b3f73a52c6ec692ae9eed37df9f9b4d595d405b44aeede29\"",
+            "etag": "W/\"45e52e0a871f7e2c311a612533c9571c3fac76e2d3f441ffbb4eb5c8b8fcc3f9\"",
             "id": "github-config:2023/12",
             "name": "2023/12",
             "repository": "github-config",
@@ -380,12 +380,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 12,
+          "index_key": "github-config-2024/01",
           "schema_version": 0,
           "attributes": {
             "color": "c7402c",
             "description": "",
-            "etag": "W/\"1853ca2bdcdfe943396f277632080edc2f5e1afed2055e0ccbfdc4177076f33d\"",
+            "etag": "W/\"242b58cb60e79053b1a6ad6ba2234dd4a2ad7c35244390f1e658a7ed2afc240f\"",
             "id": "github-config:2024/01",
             "name": "2024/01",
             "repository": "github-config",
@@ -395,12 +395,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 13,
+          "index_key": "github-config-2024/02",
           "schema_version": 0,
           "attributes": {
             "color": "5e7db9",
             "description": "",
-            "etag": "W/\"762621043e5ed7610a3c86ed330c23de05b60deccd5892b4c69fa03f990c3320\"",
+            "etag": "W/\"7251804544b31f59f6231d4c7e096ab23d313a400048aeb3c62e913558b27aca\"",
             "id": "github-config:2024/02",
             "name": "2024/02",
             "repository": "github-config",
@@ -410,12 +410,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 14,
+          "index_key": "github-config-2024/03",
           "schema_version": 0,
           "attributes": {
             "color": "e8abb9",
             "description": "",
-            "etag": "W/\"b6eaae4ebb481938b1c1a559aff3c1a0c333225719c4cf0131a5a218c508a17c\"",
+            "etag": "W/\"ef370895cc1ec19b62a85b1fa5d0180d80ad02cd23987c46c5f38a7c4fe00df9\"",
             "id": "github-config:2024/03",
             "name": "2024/03",
             "repository": "github-config",
@@ -425,12 +425,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 15,
+          "index_key": "github-config-2024/04",
           "schema_version": 0,
           "attributes": {
             "color": "9ac244",
             "description": "",
-            "etag": "W/\"0b327c371264c884dad5b03409d41170bb47a8e2d6f5ddf407a9569b8f54fd75\"",
+            "etag": "W/\"fbba7662efaef74f4057af2c4d4077d6fc71026bc0d965175bad23e0eca71ca9\"",
             "id": "github-config:2024/04",
             "name": "2024/04",
             "repository": "github-config",
@@ -440,12 +440,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 16,
+          "index_key": "github-config-2024/05",
           "schema_version": 0,
           "attributes": {
             "color": "49a099",
             "description": "",
-            "etag": "W/\"bddbdb62ae821cd0bbdd80fd31aff26e9b612fb51026c6e16bd3b17de1ea860b\"",
+            "etag": "W/\"9b200a8176163e970c848b8086a126de0ad100b05b108fbbae989a597c96c2f2\"",
             "id": "github-config:2024/05",
             "name": "2024/05",
             "repository": "github-config",
@@ -455,12 +455,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 17,
+          "index_key": "github-config-2024/06",
           "schema_version": 0,
           "attributes": {
             "color": "8e4993",
             "description": "",
-            "etag": "W/\"af2089af94074fb8bcaa56fa87b01b303542c37ab9f3c47ff4374f324ed84f5e\"",
+            "etag": "W/\"5cde7976c61ec5cdf7b879a80edf89e366abe273716dd07bf6059c53643af7c2\"",
             "id": "github-config:2024/06",
             "name": "2024/06",
             "repository": "github-config",
@@ -470,12 +470,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 18,
+          "index_key": "github-config-2024/07",
           "schema_version": 0,
           "attributes": {
             "color": "4895d0",
             "description": "",
-            "etag": "W/\"f2a50461dc228a3969e339ff854a4a3fad87e5ba8521f68b7dc8aa918e76eaa8\"",
+            "etag": "W/\"96990227d278668c4f683e353e98e5902e3dbd2962ba20ec9befe2e4f53ca3f1\"",
             "id": "github-config:2024/07",
             "name": "2024/07",
             "repository": "github-config",
@@ -485,12 +485,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 19,
+          "index_key": "github-config-2024/08",
           "schema_version": 0,
           "attributes": {
             "color": "d68838",
             "description": "",
-            "etag": "W/\"c3e35e7d7cc9ea94e703ed621f88ab3ce454539d3230cce4d8033da11876ef24\"",
+            "etag": "W/\"09a947be2142bcbfe29037bb7d627d3413cb0939109ffacd5d45c4c76ab77bd1\"",
             "id": "github-config:2024/08",
             "name": "2024/08",
             "repository": "github-config",
@@ -500,12 +500,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 20,
+          "index_key": "github-config-2024/09",
           "schema_version": 0,
           "attributes": {
             "color": "3c5929",
             "description": "",
-            "etag": "W/\"09c37df2418ed4bec2412cbe39c6a0bcc61e60e2e860f8af59aa09bb94eb26f0\"",
+            "etag": "W/\"e28caf246857a1d2d009cabaeff98aef88e33bb9927951b78bb04ccd8fbc8beb\"",
             "id": "github-config:2024/09",
             "name": "2024/09",
             "repository": "github-config",
@@ -515,12 +515,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 21,
+          "index_key": "github-config-2024/10",
           "schema_version": 0,
           "attributes": {
             "color": "e0b73e",
             "description": "",
-            "etag": "W/\"0519a2adf09f2bd8cfc9ed3be96d253a5375aa7b6711ae29c3371a5de0ca4402\"",
+            "etag": "W/\"7d342ebc0a56982872dea7aed9329584091a33b691273ef37fccc280d2713454\"",
             "id": "github-config:2024/10",
             "name": "2024/10",
             "repository": "github-config",
@@ -530,12 +530,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 22,
+          "index_key": "github-config-2024/11",
           "schema_version": 0,
           "attributes": {
             "color": "763724",
             "description": "",
-            "etag": "W/\"6709a018ebcb6853e7983810450264c937ee61b71be3d0b3735ce4f29decb008\"",
+            "etag": "W/\"bf10a5f6804695c7c45c6807c4c6c82add0d2edfe5c678a75454e24fc1e1e365\"",
             "id": "github-config:2024/11",
             "name": "2024/11",
             "repository": "github-config",
@@ -545,12 +545,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 23,
+          "index_key": "github-config-2024/12",
           "schema_version": 0,
           "attributes": {
             "color": "192983",
             "description": "",
-            "etag": "W/\"0fd7147997b759844e8c224452a611b21f00382e563a4093299d4eeb172caf6f\"",
+            "etag": "W/\"f85e663c4a9e4be1ab840b985a5de43e14f6065c136ba9cb98a6962346528e5f\"",
             "id": "github-config:2024/12",
             "name": "2024/12",
             "repository": "github-config",
@@ -560,12 +560,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 24,
+          "index_key": "tasks-2023/01",
           "schema_version": 0,
           "attributes": {
             "color": "c7402c",
             "description": "",
-            "etag": "W/\"fd98ca0e6f596ae2b3657ee432a47051190ab4dec6107bc615404642538b65df\"",
+            "etag": "W/\"b52f59b4e3b3f1d634709888a20536af4b7b04ac95c88b54b0526d0f3247df9c\"",
             "id": "tasks:2023/01",
             "name": "2023/01",
             "repository": "tasks",
@@ -575,12 +575,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 25,
+          "index_key": "tasks-2023/02",
           "schema_version": 0,
           "attributes": {
             "color": "5e7db9",
             "description": "",
-            "etag": "W/\"f93f6794bc46fe015df2100efaad79ceacacdb70e7f9988df98804c614c2ca6d\"",
+            "etag": "W/\"2e211995e119e198f4da75d75b7ea54b1f6c5b9d4cc3ee9bfc7a3123948a5724\"",
             "id": "tasks:2023/02",
             "name": "2023/02",
             "repository": "tasks",
@@ -590,12 +590,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 26,
+          "index_key": "tasks-2023/03",
           "schema_version": 0,
           "attributes": {
             "color": "e8abb9",
             "description": "",
-            "etag": "W/\"d9257bd2c4137b56b0f1bcef22fea8cb3b9f9de5b69e38e0c745707c05a54980\"",
+            "etag": "W/\"b364104f307e9230a17f3297ad5b98de84edcade187228dd33ad3905b123403b\"",
             "id": "tasks:2023/03",
             "name": "2023/03",
             "repository": "tasks",
@@ -605,12 +605,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 27,
+          "index_key": "tasks-2023/04",
           "schema_version": 0,
           "attributes": {
             "color": "9ac244",
             "description": "",
-            "etag": "W/\"cf9865655eddd9adc9214f1a913d548807d2929163b2d405bb4987cca503556b\"",
+            "etag": "W/\"450e8c371d062831160438a23f91838c7e1700c4fd1a1d7f5a97b672e1ea1861\"",
             "id": "tasks:2023/04",
             "name": "2023/04",
             "repository": "tasks",
@@ -620,12 +620,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 28,
+          "index_key": "tasks-2023/05",
           "schema_version": 0,
           "attributes": {
             "color": "49a099",
             "description": "",
-            "etag": "W/\"b77de199b5e9b36011e51b0715730d3f425e3c1ab63bc6e91b8e4faa1d0a98df\"",
+            "etag": "W/\"63567774197d8027be760941a9ded1be7774a297851912da10943e9ad129f0a5\"",
             "id": "tasks:2023/05",
             "name": "2023/05",
             "repository": "tasks",
@@ -635,12 +635,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 29,
+          "index_key": "tasks-2023/06",
           "schema_version": 0,
           "attributes": {
             "color": "8e4993",
             "description": "",
-            "etag": "W/\"bb69b8ee04ba2b8b95aefa22af36ac8411238078bb15e7d936bd2610492a2cc5\"",
+            "etag": "W/\"cb814d7f17903d2c31968acb31e1918b2071d35e325350c346a0fa0762577f3a\"",
             "id": "tasks:2023/06",
             "name": "2023/06",
             "repository": "tasks",
@@ -650,12 +650,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 30,
+          "index_key": "tasks-2023/07",
           "schema_version": 0,
           "attributes": {
             "color": "4895d0",
             "description": "",
-            "etag": "W/\"ce5ce69f065d15a0737191f1f243843611c1cd7092d484d06088136c8aecd151\"",
+            "etag": "W/\"7e6eb0dcb841f55370689d2755f6351c42bb1cdbbb46c949571792e1cbf103d2\"",
             "id": "tasks:2023/07",
             "name": "2023/07",
             "repository": "tasks",
@@ -665,12 +665,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 31,
+          "index_key": "tasks-2023/08",
           "schema_version": 0,
           "attributes": {
             "color": "d68838",
             "description": "",
-            "etag": "W/\"6b751239dda47846c7990b2a78004fad15c203095bc471473a6f308b6f5e62b2\"",
+            "etag": "W/\"b24c1064691a0de3cdd74242d821dfbc1afb6b69ff511d51c38fee5867ccad47\"",
             "id": "tasks:2023/08",
             "name": "2023/08",
             "repository": "tasks",
@@ -680,12 +680,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 32,
+          "index_key": "tasks-2023/09",
           "schema_version": 0,
           "attributes": {
             "color": "3c5929",
             "description": "",
-            "etag": "W/\"adcf091d5e1080b93ef1ffe59f38ee5c3c4c31e7730502287961e61c71ce6ff2\"",
+            "etag": "W/\"d53dd40e9e19c5fba64e32bc40679068ef5010b030104b4f6f3036a536f4b212\"",
             "id": "tasks:2023/09",
             "name": "2023/09",
             "repository": "tasks",
@@ -695,12 +695,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 33,
+          "index_key": "tasks-2023/10",
           "schema_version": 0,
           "attributes": {
             "color": "e0b73e",
             "description": "",
-            "etag": "W/\"ca0cffaedf4b5fbd6a371399725056994c248f32f09dbc8645d314bdb998238a\"",
+            "etag": "W/\"51edf3245bc521084187fcc7785f79959dc63cebfcbac0c2aba3701f6a185640\"",
             "id": "tasks:2023/10",
             "name": "2023/10",
             "repository": "tasks",
@@ -710,12 +710,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 34,
+          "index_key": "tasks-2023/11",
           "schema_version": 0,
           "attributes": {
             "color": "763724",
             "description": "",
-            "etag": "W/\"0f114b741203a923f5bc0d74a00c6296ac338e5a927e0b4ee13fb459ceb5c917\"",
+            "etag": "W/\"b1bf16901bc907368e649bf31b403bf622e2e3212f5dbcea55f11fcf3c79aeeb\"",
             "id": "tasks:2023/11",
             "name": "2023/11",
             "repository": "tasks",
@@ -725,12 +725,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 35,
+          "index_key": "tasks-2023/12",
           "schema_version": 0,
           "attributes": {
             "color": "192983",
             "description": "",
-            "etag": "W/\"2b6475db5daf26681db339056886eb2b4924f987b4deb244bd9db521c9acccdf\"",
+            "etag": "W/\"5548c4f1f284643fd50001cb1efc47aaa07acdb4211b2a3e2bbecf29bdd5d451\"",
             "id": "tasks:2023/12",
             "name": "2023/12",
             "repository": "tasks",
@@ -740,12 +740,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 36,
+          "index_key": "tasks-2024/01",
           "schema_version": 0,
           "attributes": {
             "color": "c7402c",
             "description": "",
-            "etag": "W/\"c8fc8703bc6f27cb4d0d0499ae3b4cdcb41cc7e2045eaae4da201d025323cba1\"",
+            "etag": "W/\"35c72e025c97c9265e401a85e64fc57a21a74549dc1bf52ce9340baa60b98fdf\"",
             "id": "tasks:2024/01",
             "name": "2024/01",
             "repository": "tasks",
@@ -755,12 +755,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 37,
+          "index_key": "tasks-2024/02",
           "schema_version": 0,
           "attributes": {
             "color": "5e7db9",
             "description": "",
-            "etag": "W/\"08cd95095ad951dd3b76bab72659fa9bd069b2e87aae205b827c6a6200980033\"",
+            "etag": "W/\"14a8106200b872f85812fa054b1abb7add1bbe00927e9fd3bc5c55412e55c1c1\"",
             "id": "tasks:2024/02",
             "name": "2024/02",
             "repository": "tasks",
@@ -770,12 +770,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 38,
+          "index_key": "tasks-2024/03",
           "schema_version": 0,
           "attributes": {
             "color": "e8abb9",
             "description": "",
-            "etag": "W/\"9916957b85db1820482d76e4c20c355bdf0416a3a7e1515c9b43b92f98dad70b\"",
+            "etag": "W/\"5a0c25d45b99fbb60ed56d709537eaec2c0eb82e9f3ecde9d12e13bac9413851\"",
             "id": "tasks:2024/03",
             "name": "2024/03",
             "repository": "tasks",
@@ -785,12 +785,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 39,
+          "index_key": "tasks-2024/04",
           "schema_version": 0,
           "attributes": {
             "color": "9ac244",
             "description": "",
-            "etag": "W/\"d3f24cd08e2e5ff58b80e716029f944a2a1408541580f2b77a3358155b441733\"",
+            "etag": "W/\"22b8ca0c4913e02a848c736c5dc1e5fefb28ba465aab7b9d9dcadfc98debb48b\"",
             "id": "tasks:2024/04",
             "name": "2024/04",
             "repository": "tasks",
@@ -800,12 +800,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 40,
+          "index_key": "tasks-2024/05",
           "schema_version": 0,
           "attributes": {
             "color": "49a099",
             "description": "",
-            "etag": "W/\"843f8110c4479f474bc10e3ac0ec20ae7f0abb7ff020ec1eced1aa4cb8ada196\"",
+            "etag": "W/\"35355cefe4306acc2ce594c132f8c9a7c7b350864ff2adbc5f39f534b942729e\"",
             "id": "tasks:2024/05",
             "name": "2024/05",
             "repository": "tasks",
@@ -815,12 +815,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 41,
+          "index_key": "tasks-2024/06",
           "schema_version": 0,
           "attributes": {
             "color": "8e4993",
             "description": "",
-            "etag": "W/\"a82562d7835ef947928c254e92babaebe6a859c5dd551373a6cedf756b5239c0\"",
+            "etag": "W/\"692dfccf46b6384b9c7515278f4a7e7280e003487788ecd72c5c6ab50e63c917\"",
             "id": "tasks:2024/06",
             "name": "2024/06",
             "repository": "tasks",
@@ -830,12 +830,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 42,
+          "index_key": "tasks-2024/07",
           "schema_version": 0,
           "attributes": {
             "color": "4895d0",
             "description": "",
-            "etag": "W/\"8d1e4137d11db411bd071133c8566cff7c969d6c186a02194baf693f1304eb8f\"",
+            "etag": "W/\"34755f87e996388fceb251c5bb12c2b37fa1147bf793f16ee973adf81910ff2b\"",
             "id": "tasks:2024/07",
             "name": "2024/07",
             "repository": "tasks",
@@ -845,12 +845,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 43,
+          "index_key": "tasks-2024/08",
           "schema_version": 0,
           "attributes": {
             "color": "d68838",
             "description": "",
-            "etag": "W/\"e5be48df4892ca3e1dcae3f8c9e7adc1561491d56cfcff06772257f425f6449b\"",
+            "etag": "W/\"20963398cb4e9e74680607820f4f3f85cd3950e89ab0b68353d2a66dfde6651a\"",
             "id": "tasks:2024/08",
             "name": "2024/08",
             "repository": "tasks",
@@ -860,12 +860,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 44,
+          "index_key": "tasks-2024/09",
           "schema_version": 0,
           "attributes": {
             "color": "3c5929",
             "description": "",
-            "etag": "W/\"13cacfd3313e6215fb0e17e1f5e7e0755269a33511b8a671c9f21a137f4415d9\"",
+            "etag": "W/\"b925a6ea4e3e8099ce8a12627dce3bd5ffb967ddbbd4dd4ed92169e81c9007b1\"",
             "id": "tasks:2024/09",
             "name": "2024/09",
             "repository": "tasks",
@@ -875,12 +875,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 45,
+          "index_key": "tasks-2024/10",
           "schema_version": 0,
           "attributes": {
             "color": "e0b73e",
             "description": "",
-            "etag": "W/\"4790f6b3657bb32742a7a809b92d606bdcfe2f175e1b41e880daf3fd98bd1ac5\"",
+            "etag": "W/\"47578998bb6ff4d189e4003701fb846ba9f010f2f4e152e0f7ddc1b0048fb241\"",
             "id": "tasks:2024/10",
             "name": "2024/10",
             "repository": "tasks",
@@ -890,12 +890,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 46,
+          "index_key": "tasks-2024/11",
           "schema_version": 0,
           "attributes": {
             "color": "763724",
             "description": "",
-            "etag": "W/\"a92953f0e9e7cf5dc46041df71ffd3b70fe3734bf84b5285e22b8f7072ce3e0a\"",
+            "etag": "W/\"09b9aa490fdd1adff29856ecd2375836715f7a59e8c9b199dcafaf2e3c536d38\"",
             "id": "tasks:2024/11",
             "name": "2024/11",
             "repository": "tasks",
@@ -905,12 +905,12 @@
           "private": "bnVsbA=="
         },
         {
-          "index_key": 47,
+          "index_key": "tasks-2024/12",
           "schema_version": 0,
           "attributes": {
             "color": "192983",
             "description": "",
-            "etag": "W/\"49911ff9ee65e3d433a55d468edf847dfae047cb88e3687013a0efc4a8090642\"",
+            "etag": "W/\"3c7c557bfff5837df1ac961c1014ceafde417f68f392038488424bee75a5ecec\"",
             "id": "tasks:2024/12",
             "name": "2024/12",
             "repository": "tasks",
@@ -942,7 +942,7 @@
             "default_branch": "main",
             "delete_branch_on_merge": true,
             "description": "GitHub configuration managed by terraform",
-            "etag": "W/\"d89f1d3a3afdf1293094b6347bd36586687c89daa6b4795d9fd495e0ebf40344\"",
+            "etag": "W/\"73c9b803a146853035ea4eecfa6177fc3e2c4b09859c6a021a2adb14c72c110e\"",
             "full_name": "go-zen-chu/github-config",
             "git_clone_url": "git://github.com/go-zen-chu/github-config.git",
             "gitignore_template": null,


### PR DESCRIPTION
## Why

- The problem of using count is when we changed the number of repo or year, the index of array will be changed. This cause resources to be destroyed and recreated

## What

- Changed using count -> for_each so each resources are managed not by index but map's key