### PR TITLE
chore: restrict CI auto-fix trigger to repository owner only

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -56,7 +56,7 @@ jobs:
     if: |
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'failure' &&
-      (github.event.workflow_run.actor.login == 'claude[bot]' || github.event.workflow_run.actor.login == github.repository_owner) &&
+      github.event.workflow_run.actor.login == github.repository_owner &&
       !contains(github.event.workflow_run.head_commit.message, '[claude-ci-fix]')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Why / Background of this PR

- The CI auto-fix job was also triggered when a workflow run failed under `claude[bot]`, risking unintended auto-fix loops.
- Restricting auto-fix to workflow failures caused by the repository owner's own actions prevents misfires and clarifies the scope of responsibility for auto-fix.

## What / Changes

- Removed the `github.event.workflow_run.actor.login == 'claude[bot]'` OR condition from the `if` condition of the CI auto-fix job in `.github/workflows/claude.yml`
- Limited the trigger condition to `github.event.workflow_run.actor.login == github.repository_owner` only

## Validation / QA

- Not run

## Risks

- Workflow failures caused by `claude[bot]` will no longer be auto-fixed (intended change)